### PR TITLE
remove closing tags from specified tags

### DIFF
--- a/library/src/lib.rs
+++ b/library/src/lib.rs
@@ -62,7 +62,7 @@ pub fn html2maud(html: &str) -> String {
         let tag_name = tag.name().as_utf8_str();
 
         let use_semicolon = match tag_name.as_ref().to_string().as_str() {
-            "meta" | "link" | "script" | "br" | "img" => true,
+            "meta" | "link" | "br" | "img" => true,
             _ => false,
         };
 

--- a/library/src/lib.rs
+++ b/library/src/lib.rs
@@ -62,7 +62,8 @@ pub fn html2maud(html: &str) -> String {
         let tag_name = tag.name().as_utf8_str();
 
         let use_semicolon = match tag_name.as_ref().to_string().as_str() {
-            "meta" | "link" | "br" | "img" => true,
+            "meta" | "link" | "br" | "img" | "input" | "hr" | "col" | "area" | "base" | "wbr"
+            | "track" | "param" => true,
             _ => false,
         };
 

--- a/library/src/lib.rs
+++ b/library/src/lib.rs
@@ -60,6 +60,12 @@ pub fn html2maud(html: &str) -> String {
 
     fn handle_tag(tag: &HTMLTag, parser: &Parser, maud_template: &mut String, indent: usize) {
         let tag_name = tag.name().as_utf8_str();
+
+        let use_semicolon = match tag_name.as_ref().to_string().as_str() {
+            "meta" | "link" | "script" | "br" | "img" => true,
+            _ => false,
+        };
+
         write!(maud_template, "{}{}", spaces(indent), &tag_name).unwrap();
 
         match tag.attributes().class_iter() {
@@ -105,7 +111,12 @@ pub fn html2maud(html: &str) -> String {
             }
         }
 
-        write!(maud_template, " {{\n").unwrap();
+        if !use_semicolon {
+            write!(maud_template, " {{\n").unwrap();
+        } else {
+            write!(maud_template, ";\n").unwrap();
+        }
+
         let children = tag.children();
         let nodes = children.top().as_slice();
         let mut first_node = true;
@@ -117,7 +128,10 @@ pub fn html2maud(html: &str) -> String {
             }
             handle_node(child_node.get(parser), parser, maud_template, indent + 1);
         }
-        write!(maud_template, "{}}}\n", spaces(indent)).unwrap();
+
+        if !use_semicolon {
+            write!(maud_template, "{}}}\n", spaces(indent)).unwrap();
+        }
     }
 
     fn handle_node(


### PR DESCRIPTION
This fixes the extra closing tags that were previously added to the following tags:

"meta" | "link" | "br" | "img"

before:

`link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.css"  rel="stylesheet" {}`

which maud read as:

`<link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.css"  rel="stylesheet"></link>`

with this pull request:

`link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.css"  rel="stylesheet";`

which maud reads as:

`<link href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.css"  rel="stylesheet" />`